### PR TITLE
Need to set a POSTURE when installing gems

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -72,7 +72,7 @@ cd verify_setup
 ### Install the Gems
 
 ```
-./install-gems.sh
+POSTURE=test ./install-gems.sh
 ```
 
 ### Create the Database


### PR DESCRIPTION
If you do not specify a `POSTURE`, then `install-gems.sh` will assume `operational` and not install the development dependencies like `test_bench`, which is needed by the `test.sh` run in a later step.